### PR TITLE
allow the addon to be enabled/disabled through configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,13 @@ module.exports = {
     // * running tests against production
     //
     var app = this.app || this._findHost();
-    return app.tests;
+    let addonOptions = app.options['ember-cli-deprecation-workflow'];
+
+    if (addonOptions) {
+      return addonOptions.enabled;
+    } else {
+      return app.tests;
+    }
   },
 
   included: function() {


### PR DESCRIPTION
This allows the addon to be enabled / disabled through configuration in `ember-cli-build.js`:

```js
'ember-cli-deprecation-workflow': {
  enabled: true,
},
```

Let's use this in our app for a little while first before considering if we should try to upstream it to https://github.com/mixonic/ember-cli-deprecation-workflow